### PR TITLE
HexChat doesn't offer binaries for macOS aynmore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -392,7 +392,6 @@ apps = ![Dollar][mon]. If an app dosen't have either icon then it should be cons
 
 ### IRC Clients
 
-- [HexChat](https://hexchat.github.io/) - IRC client based on XChat. ![Open Source][oss]
 - [Irssi](https://irssi.org/) - Your text mode chatting application since 1999. ![Open Source][oss]
 - [KVIrc](http://kvirc.net/) - QT IRC Client. ![Open Source][oss]
 - [LimeChat](http://limechat.net/mac/) - LimeChat is an IRC client for MacOS. ![Open Source][oss]


### PR DESCRIPTION
While technically speaking you're free to build HexChat (super piece of software my favorite IRC client... but kind of old) yourself, if you visit [them](https://hexchat.github.io/), you'll see there's sadly no macOS build. 😢