### PR TITLE
Remove `LiteIcon` as it has been discontinued

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -877,7 +877,6 @@ androids, cyborgs, supercomputers, etc.
 - [KeyCue](https://www.ergonis.com/products/keycue/) - Find, remember, and learn keyboard shortcuts. ![Dollar][mon]
 - [Keysmith](https://www.keysmith.app/) - Create custom keyboard shortcuts for anything. ![Dollar][mon]
 - [LaunchRocket](https://github.com/jimbojsb/launchrocket) - PrefPane to manage all your Homebrew-installed services. ![Open Source][oss]
-- [LiteIcon](http://www.freemacsoft.net/liteicon/) - LiteIcon is a simple app which allows you to change your system icons.
 - [Lunar](https://lunar.fyi/) - Intelligent adaptive brightness for your external display. ![Open Source][oss]
 - [Maccy](https://maccy.app/) - Clipboard manager for macOS.
 - [MacUpdater](https://www.corecode.io/macupdater/) - Keep all your apps up-to-date effortlessly. ![Dollar][mon] ![Star][fav]


### PR DESCRIPTION
As of the official homepage

> End of the road...
> We are sorry to announce that LiteIcon has been discontinued, as it is no longer possible to replace system icons on macOS Big Sur.