### PR TITLE
Add RemoveX

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -187,6 +187,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Disk Doctor](https://fiplab.com/apps/disk-doctor-for-mac) - Removes tons of unneeded files. ![Dollar][mon]
 - [Duplicate Detective](https://fiplab.com/apps/duplicate-detective-for-mac) - Remove duplicate files from your Mac. ![Dollar][mon]
 - [Monolingual](http://ingmarstein.github.io/Monolingual/) - Frees up disk space by removing unused languages files. ![Open Source][oss]
+- [RemoveX](https://removex.io) - Uninstaller tool for Mac computer. RemoveX has a beautifully UI using native design for MacOS. Save hours of time and remove your app in seconds. Do not make you think. ![Free][free] and ![Dollar][mon]
 - [TrashMe](http://www.jibapps.com/en/products/trashme/) - Uninstaller for the Mac with other great useful tools. ![Dollar][mon] ![Star][fav]
 
 ### Clipboard Managers


### PR DESCRIPTION
Dear sir,

[RemoveX](https://removex.io) - Uninstaller tool for Mac computer. RemoveX has a beautifully UI using native design for MacOS. Save hours of time and remove your app in seconds. Do not make you think.

We build RemoveX with a simple way to think, a simple way to use it and really focus on user requirements - uninstall an application as fast as possible.

User will not waste their money on features they do not need, do not understand, sometimes it is useless and rarely to use any more when making a comparison with other complex app.

Thank you for your time and hope you have a nice day.