### PR TITLE
Add Input Source Pro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -547,6 +547,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Hidden](https://github.com/dwarvesf/hidden) - Lets you hide menu bar items. ![Open Source][oss] - Editor's Choice.
 - [HotSwitch](https://oniatsu.github.io/HotSwitch/) - Fastest window switcher app. ![Open Source][oss]
 - [HyperSwitch](https://bahoom.com/hyperswitch/) - Keyboard window switcher for macOS. ![Dollar][mon]
+- [Input Source Pro](https://inputsource.pro/) - Switch and track your input sources with ease ✨.
 - [KeyCue](https://www.ergonis.com/products/keycue/) - Find, remember, and learn keyboard shortcuts. ![Dollar][mon]
 - [NightOwl](https://nightowl.kramser.xyz/#) - Easily toggle dark mode on macOS. ![Open Source][oss]
 - [MenuBar Stats 3](https://seense.com/menubarstats/) - Advanced macOS System Monitor. ![Dollar][mon]


### PR DESCRIPTION
Input Source Pro is a tool designed for multilingual Mac users. It can automatically change input sources based on the applications and websites users interact with. It also conveniently displays the current input source through an easy-to-read tooltip.