### PR TITLE
Replace Cakebrew with Cork

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -718,7 +718,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 
 ### Package Management
 
-- [Cakebrew](https://www.cakebrew.com/) - The Mac App for Homebrew. ![Open Source][oss]
+- [Cork](https://www.corkmac.app/) - The ultimate Homebrew companion. ![Open Source][oss] & ![Dollar][mon]
 - [Fink](http://www.finkproject.org/) - Debian package management for macOS. ![Open Source][oss]
 - [Homebrew](http://brew.sh/) - The missing package manager for macOS. ![Open Source][oss] ![Star][fav]
 - [MacPorts](https://www.macports.org/) - A package management system for macOS. ![Open Source][oss]


### PR DESCRIPTION
This might be a bold thing to do, but I believe it is warranted:
- Cakebrew has been abandoned for over two years, Cork is being actively developed
- [The developer of Cakebrew himself discourages its use](https://github.com/phmullins/awesome-macos/assets/22037369/ecdaea29-6661-4839-a5d9-6ef26dbae8c0)
- Both apps do the same thing, while Cork is more feature-complete than Cakebrew

