### PR TITLE
Label Blender as OSS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -437,7 +437,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 
 ### Game Development
 
-- [Blender](https://www.blender.org/) - A new era for content creation. ![Free][free]
+- [Blender](https://www.blender.org/) - A new era for content creation. ![Open Source][oss]
 - [Godot](https://godotengine.org/) - Free and open source game engine. Loved by indie devs. ![Open Source][oss]
 - [Unity](https://unity.com/) - The platform of choice for multiplayer hits. ![Free][free]
 - [Unreal Engine](https://www.unrealengine.com/en-US/) - The world’s most open and advanced real-time 3D creation tool. ![Free][free]


### PR DESCRIPTION
Given that it is released under GNU General Public License, it should be considere OSS https://github.com/blender/blender/blob/main/doc/license/GPL-license.txt