### PR TITLE
Add entry for Sweet Home 3D in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -626,6 +626,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [NetNewsWire](https://ranchero.com/netnewswire/) - More news, less junk. Faster. ![Free][free]
 - [PiBakery](https://www.pibakery.org/) - The easiest way to setup a Raspberry Pi. ![Free][free]
 - [QLMarkdown](https://github.com/sbarex/QLMarkdown) - Quick Look extension for Markdown files. ![Open Source][oss]
+- [Sweet Home 3D](https://www.sweethome3d.com) - Free interior design application. ![Open Souce][oss]
 - [Reeder 5](https://reeder.app/) - The best news reader for macOS. ![Dollar][mon]
 - [ResXtreme](http://resxtreme.com/) - Provides access to all display modes. ![Dollar][mon]
 - [RightFont 5](https://rightfontapp.com/) - Professional font manager app for Mac. ![Dollar][mon]


### PR DESCRIPTION
Sweet Home 3D is a free interior design application which helps you draw the plan of your house, arrange furniture on it and visit the results in 3D.
License is GPLv2 as stated here:
https://www.sweethome3d.com/license.jsp
https://sourceforge.net/projects/sweethome3d/
Just to make sure my intent is clear, I use Sweet Home 3D and as I have found your directory quise useful, I think it should be added