### PR TITLE
Remove Clean-Me from readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,6 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 ### Cleanup
 
 - [BlueHarvest](https://zeroonetwenty.com/blueharvest/) - Keep your disks clean of macOS metadata. ![Dollar][mon]
-- [Clean-Me](https://github.com/Kevin-De-Koninck/Clean-Me) - A macOS system analyser and cleaner. ![Free][free]
 - [CleanMyMac X](https://macpaw.com/cleanmymac) - Your Mac. As good as new. ![Dollar][mon] ![Star][fav]
 - [Daisy Disk](https://daisydiskapp.com/) - What’s taking up your disk space? ![Dollar][mon] ![Star][fav]
 - [Disk Doctor](https://fiplab.com/apps/disk-doctor-for-mac) - Removes tons of unneeded files. ![Dollar][mon]


### PR DESCRIPTION
As mentioned in https://github.com/Kevin-De-Koninck/Clean-Me this repository has been archived since Jan 6, 2022, so I think it is best to remove it