### PR TITLE
Add SaneClip to Clipboard Managers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,6 +193,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 
 - [Copied](https://copied.app/) - Clipboard manager for macOS, iOS and iPadOS. ![Dollar][mon]
 - [Maccy](https://maccy.app/) - Keep your copy history at hand. Period. ![Open Source][oss]
+- [SaneClip](https://saneclip.com/) - Fast clipboard manager that keeps all history local. ![Open Source][oss] ![Free][free]
 - [Yippy](https://yippy.mattdavo.com/) - An open source clipboard manager for macOS. ![Open Source][oss]
 
 ### Cloud Storage


### PR DESCRIPTION
Adding SaneClip to the Clipboard Managers section.

SaneClip is a fast macOS clipboard manager that keeps all history local on your device. No cloud sync, no telemetry, no account required. Free with optional Pro upgrade.

- Website: https://saneclip.com
- Source: https://github.com/sane-apps/SaneClip
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license

Disclosure: I am the developer of SaneClip.
