### PR TITLE
Add SaneClick to System Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -991,6 +991,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Pock](http://pock.pigigaldi.com/) - Display macOS Dock in Touch Bar. ![Open Source][oss]
 - [PrefsEditor](https://apps.tempel.org/PrefsEditor/) - A GUI for the 'defaults' command. ![Free][free]
 - [Rocket](https://matthewpalmer.net/rocket/) - Mind-blowing emoji on your Mac. ![Free][free]
+- [SaneClick](https://saneclick.com/) - Finder toolbar customizer for adding quick actions. ![Open Source][oss] ![Free][free]
 - [Service Station](https://servicestation.menu/) - Customize your Right-Click Menu. ![Free][free] ![Star][fav]
 - [Shottr](https://shottr.cc/) - Screenshot tool for those who care about pixels. ![Free][free]
 - [Sidebar](https://sidebarapp.net/) - The modern Dock replacement for your Mac. ![Dollar][mon]


### PR DESCRIPTION
Adding SaneClick to the System Tools section.

SaneClick is a macOS Finder toolbar customizer for adding quick actions. Fully local, no telemetry, no account required. Free with optional Pro upgrade.

- Website: https://saneclick.com
- Source: https://github.com/sane-apps/SaneClick
- License: PolyForm Shield — source-available and free for personal use and experimentation; commercial use requires a license

Disclosure: I am the developer of SaneClick.
