### PR TITLE
Add HeyRobyn to Communication section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Canary](https://canarymail.io/) - Secure Email App for Mac and iPhone. ![Dollar][mon]
 - [eM Client](https://www.emclient.com) - Boost your email. Skyrocket your productivity. Free & ![Dollar][mon] ![Star][fav]
 - [FMail](https://fmail-app.fr/index.html?22050731) - The free native Mac application for Fastmail users. ![Free][free]
+- [HeyRobyn](https://heyrobyn.ai/) - Native Mac unified inbox for email, Slack, and GitHub. ![Free][free]
 - [imap-backup](https://github.com/joeyates/imap-backup) - Backup IMAP accounts to disk. ![Open Source][oss] 
 - [MailMate](https://freron.com/) - IMAP email client for macOS. ![Dollar][mon]
 - [Mailspring](https://getmailspring.com/) - Boost your productivity and send better emails. ![Free][free]


### PR DESCRIPTION
## Summary

- Adds [HeyRobyn](https://heyrobyn.ai) to the **Communication** section in alphabetical order.
- HeyRobyn is a unified inbox for macOS that brings email, Slack, GitHub, and more into one native window with an AI assistant.
- Entry follows the existing list format and is marked as ![Free][free].

## Details

HeyRobyn consolidates multiple communication channels (email, Slack, GitHub notifications, and more) into a single native macOS application, with a built-in AI assistant to help manage messages and tasks.