### PR TITLE
Add HeyRobyn - Native Mac unified inbox

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,6 +346,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Canary](https://canarymail.io/) - Secure Email App for Mac and iPhone. ![Dollar][mon]
 - [eM Client](https://www.emclient.com) - Boost your email. Skyrocket your productivity. Free & ![Dollar][mon] ![Star][fav]
 - [FMail](https://fmail-app.fr/index.html?22050731) - The free native Mac application for Fastmail users. ![Free][free]
+- [HeyRobyn](https://heyrobyn.ai/) - Native Mac unified inbox for email, Slack, and GitHub. ![Dollar][mon]
 - [imap-backup](https://github.com/joeyates/imap-backup) - Backup IMAP accounts to disk. ![Open Source][oss] 
 - [MailMate](https://freron.com/) - IMAP email client for macOS. ![Dollar][mon]
 - [Mailspring](https://getmailspring.com/) - Boost your productivity and send better emails. ![Free][free]


### PR DESCRIPTION
**HeyRobyn** is a native macOS application that brings email, Slack, and GitHub notifications into a single unified inbox.

**Key Features:**
- Built entirely in SwiftUI (not Electron) for true native performance
- Unified inbox for email, Slack, and GitHub
- Privacy-first architecture with all data stored on-device
- Available at https://heyrobyn.ai

This PR adds HeyRobyn to the Email section, alphabetically placed between FMail and imap-backup.

Thank you for maintaining this excellent list!