### PR TITLE
Add WiFi & IP Info to Menubar Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -576,6 +576,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Tyke](https://tyke.app/) - A little bit of scratch paper. ![Free][free]
 - [Vanilla](http://matthewpalmer.net/vanilla/) - Hide menu bar icons on your Mac. ![Free][free]
 - [WhichSpace](https://github.com/gechr/WhichSpace) - Active space menu bar icon for macOS. ![Open Source][oss]
+- [WiFi & IP Info](https://wifiipinfo.bushev.dev/) - View WiFi signal strength, IP address, and latency from the macOS menu bar. ![Dollar][mon]
 - [xbar](https://xbarapp.com) - Put anything in your macOS menu bar. ![Open Source][oss]
 - [XMenu](https://www.devontechnologies.com/apps/freeware) - Directly access all your apps from the manu bar. ![Free][free]
 - [NotchNook](https://lo.cafe/notchnook) - Interactive use of notch area. ![Dollar][mon]


### PR DESCRIPTION
Adds WiFi & IP Info, a macOS menu bar app for viewing WiFi signal strength, IP address, and latency.

Lightweight native utility that provides quick access to network information directly from the menu bar.