### PR TITLE
Add Juicy Battery

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -580,6 +580,8 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [XMenu](https://www.devontechnologies.com/apps/freeware) - Directly access all your apps from the manu bar. ![Free][free]
 - [NotchNook](https://lo.cafe/notchnook) - Interactive use of notch area. ![Dollar][mon]
 - [Alcove](https://tryalcove.com) - Dynamic Island for your Mac. ![Dollar][mon]
+- [Juicy](https://getjuicy.app) - Custom battery alerts & health monitoring for your Mac. ![Free][free]  ![Dollar][mon]
+
 
 ### Messenger Applications
 


### PR DESCRIPTION
Appended Juicy to the Menu Bar Apps section.

I'm Dom, the indie dev of [Juicy](https://getjuicy.app). Juicy is a Mac battery app that sits in your menu bar and allows for custom battery alerts, charging limits, device battery tracking, app drainer insights and more. 

It has been featured multiple times by Apple in the Mac App Store and now I have also released a direct download version with more powerful features. 

Would highly appreciate if it could get added to the list! :)