### PR TITLE
Add Atoll to Menubar Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -539,6 +539,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 
 ### Menubar Applications
 
+- [Atoll](https://github.com/Ebullioscopic/Atoll) - Feature packed DynamicIsland for your Mac. ![Open Source][oss]
 - [Aldente](https://github.com/davidwernhart/AlDente) - macOS tool to limit maximum charging percentage. ![Open Source][oss]
 - [Amphetamine](https://apps.apple.com/us/app/amphetamine/id937984704?mt=12) - The most awesome keep-awake app ever created for macOS.
 - [Apple Juice](https://github.com/raphaelhanneken/apple-juice) - Advanced battery gauge for macOS. ![Open Source][oss]


### PR DESCRIPTION
## What
Adds [Atoll](https://github.com/Ebullioscopic/Atoll) to the **MenuBar Applications** section.

## Why
Atoll is an Open Source macOS App that turns the MacBook notch into a focused command surface for media, system insight, and quick utilities. It stays out of the way until needed, then expands with responsive, native SwiftUI animations.

- Website: https://getatoll.app/
- Source code: https://github.com/Ebullioscopic/Atoll (GPL v3)

## Checklist
- [x] Entry follows the existing bullet format with the `![Open Source][oss]` badge
- [x] Description is accurate and concise
- [x] Not a duplicate (searched existing entries)
