### PR TITLE
Add Tracexy to Networking Applications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -678,6 +678,7 @@ Audio and Music players, Trackers, Digital Audio Workstation software.
 - [Surge](http://nssurge.com/) - Advanced Web Debugging Proxy for macOS & iOS. ![Dollar][mon]
 - [SwitchHosts](https://oldj.github.io/SwitchHosts/) - Hosts management & switching. ![Open Source][oss]
 - [Termius](https://www.termius.com/) - SSH client that works on Desktop and Mobile. ![Dollar][mon]
+- [Tracexy](https://rockxy.io/tracexy) - Native macOS network intelligence app for investigating live traffic and PCAP/PCAPNG captures. ![Open Source][oss]
 - [Transfer](https://www.intuitibits.com/products/transfer/) - TFTP server for your Mac. ![Dollar][mon]
 - [Transmission](https://transmissionbt.com/download/) - Easy, free BitTorrent client. ![Open Source][oss]
 - [Usenapp](https://www.usenapp.com/) - The most complete usenet client for macOS. ![Dollar][mon]


### PR DESCRIPTION
## What changed

- Add Tracexy to the Networking Applications section.
- Describe it as a native macOS network intelligence app for live traffic and PCAP/PCAPNG investigation.
- Mark it as open source.

## Why

Tracexy is an open-source native macOS network intelligence app for investigating live traffic and PCAP/PCAPNG captures.

## Notes

Tracexy is currently under active MVP development; the entry describes the implemented capture and investigation workflow without implying a stable public release.

## Validation

- Verified the official website returns HTTP 200.
- Kept the entry alphabetically ordered within the Networking Applications section.
- Ran `git diff --check`.
